### PR TITLE
TradingChartData use on_chart to store Overlay trait

### DIFF
--- a/rust-lib/hk-trading/examples/candles_chart.rs
+++ b/rust-lib/hk-trading/examples/candles_chart.rs
@@ -18,7 +18,7 @@ fn main() {
     println!("Load file: {}", file_path.display());
 
     candle_chart_csv_dir.push("candles_chart.svg");
-    let candle_chart_csv_file_path = candle_chart_csv_dir.to_str().unwrap();
+    let candle_chart_csv_file_path = candle_chart_csv_dir.to_str().unwrap().to_owned();
     println!("Write SVG to file: {}", candle_chart_csv_file_path);
 
     /*
@@ -64,7 +64,8 @@ fn main() {
     /*
        Draw chart
     */
-    let drawing_backend = SVGBackend::with_file_path(candle_chart_csv_file_path, (width, height));
+    let drawing_backend =
+        SVGBackend::with_file_path(candle_chart_csv_file_path.as_str(), (width, height));
     let drawing_area = drawing_backend.into_drawing_area();
     drawing_area.fill(&BLACK_1).unwrap();
 
@@ -76,10 +77,10 @@ fn main() {
         .unwrap();
 
     let mut trading_chart_data = TradingChartData::new();
-    trading_chart_data.with_ohlc_overlay(ohlcs);
-    // chart_context.s
-    // drawing_area.
-    trading_chart_data.draw(&mut chart_context).unwrap();
+    trading_chart_data
+        .add_on_chart_overlay(Box::new(ohlcs))
+        .draw(&mut chart_context)
+        .unwrap();
 
     drawing_area.present().expect("Expect");
 }

--- a/rust-lib/hk-trading/src/charts/chart_svg_drawing.rs
+++ b/rust-lib/hk-trading/src/charts/chart_svg_drawing.rs
@@ -2,10 +2,10 @@ use hk_infra::{future::HkFutureResult, HkError};
 
 use super::TradingChartData;
 
-pub struct ChartSVGDrawingContext<'a> {
+pub struct ChartSVGDrawingContext {
     pub width: u32,
     pub height: u32,
-    pub data: &'a TradingChartData,
+    // pub data: &'a TradingChartData,
 }
 
 pub trait ChartSVGDrawing {

--- a/rust-lib/hk-trading/src/charts/mod.rs
+++ b/rust-lib/hk-trading/src/charts/mod.rs
@@ -1,7 +1,7 @@
 mod trading_chart;
 pub use trading_chart::*;
-mod chart_svg_drawing;
-pub use chart_svg_drawing::*;
+// mod chart_svg_drawing;
+// pub use chart_svg_drawing::*;
 mod backend;
 pub use backend::*;
 

--- a/rust-lib/hk-trading/src/charts/overlays/mod.rs
+++ b/rust-lib/hk-trading/src/charts/overlays/mod.rs
@@ -7,22 +7,33 @@ use super::{
     context::ChartContext, coord::CoordTranslate, drawing::DrawingAreaErrorKind, DrawingBackend,
 };
 
-mod ohlc;
-pub use ohlc::OhlcOverlay;
+mod ohlcs;
+pub use ohlcs::OhlcOverlay;
 
-pub trait OverlayData<T, S> {
+pub trait OverlayData<DataType, Setting> {
     fn overlay_name(&self) -> &str;
     fn overlay_type(&self) -> &str;
-    fn overlay_data<'a>(&self) -> Option<Arc<T>>;
+    fn overlay_data<'a>(&self) -> Option<Arc<DataType>>;
     // fn overlay_data_mut(&mut self) -> Option<Arc<T>>;
 
     // The higher value, the topper it is drawed on other overlays
     fn priority(&self) -> u32;
     //TODO: Support gettings later
-    fn get_settings(&self) -> &S;
+    fn get_settings(&self) -> &Setting;
 }
 
 pub trait OverlayDrawing<DB: DrawingBackend, CT: CoordTranslate> {
+    fn draw<'a>(
+        &mut self,
+        chart_context: &mut ChartContext<'a, DB, CT>,
+    ) -> Result<(), DrawingAreaErrorKind<DB::ErrorType>>;
+}
+
+pub trait Overlay<DB: DrawingBackend, CT: CoordTranslate> {
+    fn overlay_name(&self) -> &str;
+    fn overlay_type(&self) -> &str;
+    fn priority(&self) -> u32;
+
     fn draw<'a>(
         &mut self,
         chart_context: &mut ChartContext<'a, DB, CT>,


### PR DESCRIPTION
- Remove the Ohlc Overlay and EMA overlay in TradingChartData